### PR TITLE
Add default database "postgres" to ServerConnectionString for Postgres & update nugets to latest stable

### DIFF
--- a/src/Shaolinq.Postgres.DotConnect/Shaolinq.Postgres.DotConnect.csproj
+++ b/src/Shaolinq.Postgres.DotConnect/Shaolinq.Postgres.DotConnect.csproj
@@ -94,13 +94,13 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Devart.Data, Version=5.0.1125.0, Culture=neutral, PublicKeyToken=09af7300eec23701, processorArchitecture=MSIL">
+    <Reference Include="Devart.Data, Version=5.0.1134.0, Culture=neutral, PublicKeyToken=09af7300eec23701, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\dotConnect.Express.for.PostgreSQL.7.3.333\lib\Devart.Data.dll</HintPath>
+      <HintPath>..\packages\dotConnect.Express.for.PostgreSQL.7.3.342\lib\Devart.Data.dll</HintPath>
     </Reference>
-    <Reference Include="Devart.Data.PostgreSql, Version=7.3.333.0, Culture=neutral, PublicKeyToken=09af7300eec23701, processorArchitecture=MSIL">
+    <Reference Include="Devart.Data.PostgreSql, Version=7.3.342.0, Culture=neutral, PublicKeyToken=09af7300eec23701, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\dotConnect.Express.for.PostgreSQL.7.3.333\lib\Devart.Data.PostgreSql.dll</HintPath>
+      <HintPath>..\packages\dotConnect.Express.for.PostgreSQL.7.3.342\lib\Devart.Data.PostgreSql.dll</HintPath>
     </Reference>
     <Reference Include="Platform, Version=1.1.0.196, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Shaolinq.Postgres.DotConnect/app.config
+++ b/src/Shaolinq.Postgres.DotConnect/app.config
@@ -3,6 +3,6 @@
   
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" /></startup><system.data> 
    <DbProviderFactories> 
-     <add name="dotConnect for PostgreSQL" invariant="Devart.Data.PostgreSql" description="Devart dotConnect for PostgreSQL" type="Devart.Data.PostgreSql.PgSqlProviderFactory, Devart.Data.PostgreSql, Version= 7.3.333.0, Culture=neutral, PublicKeyToken=09af7300eec23701" />
+     <add name="dotConnect for PostgreSQL" invariant="Devart.Data.PostgreSql" description="Devart dotConnect for PostgreSQL" type="Devart.Data.PostgreSql.PgSqlProviderFactory, Devart.Data.PostgreSql, Version= 7.3.342.0, Culture=neutral, PublicKeyToken=09af7300eec23701" />
    </DbProviderFactories> 
   </system.data></configuration>

--- a/src/Shaolinq.Postgres.DotConnect/packages.config
+++ b/src/Shaolinq.Postgres.DotConnect/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotConnect.Express.for.PostgreSQL" version="7.3.333" targetFramework="net40" />
+  <package id="dotConnect.Express.for.PostgreSQL" version="7.3.342" targetFramework="net40" />
   <package id="Platform.NET" version="1.1.0.196" targetFramework="net40" />
   <package id="Platform.Xml.Serialization" version="1.1.0.196" targetFramework="net40" />
 </packages>

--- a/src/Shaolinq.Postgres/PostgresSqlDatabaseContext.cs
+++ b/src/Shaolinq.Postgres/PostgresSqlDatabaseContext.cs
@@ -39,7 +39,7 @@ using Shaolinq.Postgres.Shared;
 			this.CommandTimeout = TimeSpan.FromSeconds(contextInfo.CommandTimeout);
 
 			this.ConnectionString = String.Format("Host={0};User Id={1};Password={2};Database={3};Port={4};Pooling={5};MinPoolSize={6};MaxPoolSize={7};Enlist=false;Timeout={8};CommandTimeout={9}", contextInfo.ServerName, contextInfo.UserId, contextInfo.Password, contextInfo.DatabaseName, contextInfo.Port, contextInfo.Pooling, contextInfo.MinPoolSize, contextInfo.MaxPoolSize, contextInfo.ConnectionTimeout, contextInfo.CommandTimeout);
-			this.ServerConnectionString = String.Format("Host={0};User Id={1};Password={2};Port={4};Pooling={5};MinPoolSize={6};MaxPoolSize={7};Enlist=false;Timeout={8};CommandTimeout={9}", contextInfo.ServerName, contextInfo.UserId, contextInfo.Password, contextInfo.DatabaseName, contextInfo.Port, contextInfo.Pooling, contextInfo.MinPoolSize, contextInfo.MaxPoolSize, contextInfo.ConnectionTimeout, contextInfo.CommandTimeout);
+			this.ServerConnectionString = String.Format("Host={0};User Id={1};Password={2};Database={3};Port={4};Pooling={5};MinPoolSize={6};MaxPoolSize={7};Enlist=false;Timeout={8};CommandTimeout={9}", contextInfo.ServerName, contextInfo.UserId, contextInfo.Password, "postgres", contextInfo.Port, contextInfo.Pooling, contextInfo.MinPoolSize, contextInfo.MaxPoolSize, contextInfo.ConnectionTimeout, contextInfo.CommandTimeout);
 
 			this.SchemaManager = new PostgresSharedSqlDatabaseSchemaManager(this);
 		}

--- a/src/Shaolinq.Postgres/Shaolinq.Postgres.csproj
+++ b/src/Shaolinq.Postgres/Shaolinq.Postgres.csproj
@@ -95,12 +95,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Npgsql.2.2.2\lib\net40\Mono.Security.dll</HintPath>
+      <Private>True</Private>
+      <HintPath>..\packages\Npgsql.2.2.4.3\lib\net40\Mono.Security.dll</HintPath>
     </Reference>
-    <Reference Include="Npgsql, Version=2.2.1.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+    <Reference Include="Npgsql, Version=2.2.4.3, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Npgsql.2.2.2\lib\net40\Npgsql.dll</HintPath>
+      <HintPath>..\packages\Npgsql.2.2.4.3\lib\net40\Npgsql.dll</HintPath>
     </Reference>
     <Reference Include="Platform, Version=1.1.0.196, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Shaolinq.Postgres/packages.config
+++ b/src/Shaolinq.Postgres/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Npgsql" version="2.2.2" targetFramework="net40" />
+  <package id="Npgsql" version="2.2.4.3" targetFramework="net40" />
   <package id="Platform.NET" version="1.1.0.196" targetFramework="net40" />
   <package id="Platform.Xml.Serialization" version="1.1.0.196" targetFramework="net40" />
 </packages>

--- a/src/Shaolinq.Sqlite/Shaolinq.Sqlite.csproj
+++ b/src/Shaolinq.Sqlite/Shaolinq.Sqlite.csproj
@@ -97,11 +97,13 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EntityFramework">
-      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.dll</HintPath>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\EntityFramework.6.1.2\lib\net40\EntityFramework.dll</HintPath>
     </Reference>
-    <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\EntityFramework.6.1.2\lib\net40\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Shaolinq.Sqlite/packages.config
+++ b/src/Shaolinq.Sqlite/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.1" targetFramework="net40" />
+  <package id="EntityFramework" version="6.1.2" targetFramework="net40" />
   <package id="log4net" version="2.0.3" targetFramework="net40" />
   <package id="MSBuild.NugetContentRestore" version="0.1.6" targetFramework="net40" />
   <package id="Platform.NET" version="1.1.0.196" targetFramework="net40" />

--- a/src/Shaolinq/Persistence/Linq/Sql92QueryFormatter.cs
+++ b/src/Shaolinq/Persistence/Linq/Sql92QueryFormatter.cs
@@ -1184,6 +1184,7 @@ namespace Shaolinq.Persistence.Linq
 				if (simpleConstraintExpression.Value != null)
 				{
 					this.Write("DEFAULT");
+					this.Write(" ");
 					this.Write(simpleConstraintExpression.Value);
 				}
 				break;

--- a/tests/Shaolinq.Tests/Shaolinq.Tests.csproj
+++ b/tests/Shaolinq.Tests/Shaolinq.Tests.csproj
@@ -72,19 +72,21 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EntityFramework">
-      <HintPath>..\..\src\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.dll</HintPath>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\src\packages\EntityFramework.6.1.2\lib\net40\EntityFramework.dll</HintPath>
     </Reference>
-    <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\..\src\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\src\packages\EntityFramework.6.1.2\lib\net40\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\src\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\..\src\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Platform, Version=1.1.0.196, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/tests/Shaolinq.Tests/packages.config
+++ b/tests/Shaolinq.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.1" targetFramework="net40" />
+  <package id="EntityFramework" version="6.1.2" targetFramework="net40" />
   <package id="log4net" version="2.0.3" targetFramework="net40" />
   <package id="MSBuild.NugetContentRestore" version="0.1.6" targetFramework="net40" />
-  <package id="NUnit" version="2.6.3" targetFramework="net40" />
+  <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="Platform.NET" version="1.1.0.196" targetFramework="net40" />
   <package id="Platform.Xml.Serialization" version="1.1.0.196" targetFramework="net40" />
   <package id="System.Data.SQLite" version="1.0.94.1" targetFramework="net40" />


### PR DESCRIPTION
- Without a default database in ServerConnectionString, Postgres defaults to database name of the same username. If that doesn't exist, the connection fails.