### PR TITLE
Use DataAccessObject as primary key type

### DIFF
--- a/tests/Shaolinq.Tests/PrimaryKeyTests.cs
+++ b/tests/Shaolinq.Tests/PrimaryKeyTests.cs
@@ -413,5 +413,21 @@ namespace Shaolinq.Tests
 				);
 			}
 		}
+
+		[Test]
+		[Ignore]
+		public void Test_Create_Object_With_Dao_Primary_Key()
+		{
+			using (var scope = new TransactionScope())
+			{
+				var parentObject = this.model.ObjectWithManyTypes.Create();
+
+				scope.Flush(this.model);
+
+				var childObject = this.model.ObjectWithDaoPrimaryKeys.Create(parentObject);
+
+				scope.Complete();
+			}
+		}
 	}
 }

--- a/tests/Shaolinq.Tests/Shaolinq.Tests.csproj
+++ b/tests/Shaolinq.Tests/Shaolinq.Tests.csproj
@@ -147,6 +147,7 @@
     <Compile Include="TestModel\IIdentified.cs" />
     <Compile Include="TestModel\Lecture.cs" />
     <Compile Include="TestModel\ObjectWithCompositePrimaryKey.cs" />
+    <Compile Include="TestModel\ObjectWithDaoPrimaryKey.cs" />
     <Compile Include="TestModel\ObjectWithManyTypes.cs" />
     <Compile Include="TestModel\Paper.cs" />
     <Compile Include="TestModel\TestDataAccessModel.cs" />

--- a/tests/Shaolinq.Tests/TestModel/ObjectWithDaoPrimaryKey.cs
+++ b/tests/Shaolinq.Tests/TestModel/ObjectWithDaoPrimaryKey.cs
@@ -1,0 +1,10 @@
+namespace Shaolinq.Tests.TestModel
+{
+	[DataAccessObject]
+	public abstract class ObjectWithDaoPrimaryKey
+		: DataAccessObject<ObjectWithManyTypes>
+	{
+		[PersistedMember]
+		public abstract string Something { get; set; }
+	}
+}

--- a/tests/Shaolinq.Tests/TestModel/TestDataAccessModel.cs
+++ b/tests/Shaolinq.Tests/TestModel/TestDataAccessModel.cs
@@ -66,6 +66,9 @@ namespace Shaolinq.Tests.TestModel
 		public abstract DataAccessObjects<ObjectWithLongNonAutoIncrementPrimaryKey> ObjectWithLongNonAutoIncrementPrimaryKeys { get; }
 
 		[DataAccessObjects]
+		public abstract DataAccessObjects<ObjectWithDaoPrimaryKey> ObjectWithDaoPrimaryKeys { get; }
+
+		[DataAccessObjects]
 		public abstract DataAccessObjects<ObjectWithManyTypes> ObjectWithManyTypes { get; }
 
 		[DataAccessObjects]


### PR DESCRIPTION
Allow creation of a DataAccessObject whose primary key is also a foreign key to another object's primary key.