### PR TITLE
Error storing null enum values

### DIFF
--- a/src/Shaolinq.Postgres/PostgresSqlTransactionalCommandsContext.cs
+++ b/src/Shaolinq.Postgres/PostgresSqlTransactionalCommandsContext.cs
@@ -73,12 +73,12 @@ namespace Shaolinq.Postgres
 
 			if (unwrapped.IsEnum)
 			{
-				return new NpgsqlParameter(parameterName, NpgsqlDbType.Unknown) { Value = value };
+				return new NpgsqlParameter(parameterName, NpgsqlDbType.Unknown) { Value = value ?? DBNull.Value };
 			}
 
 			if (unwrapped == typeof(TimeSpan))
 			{
-				return new NpgsqlParameter(parameterName, NpgsqlDbType.Interval) { Value = value };
+				return new NpgsqlParameter(parameterName, NpgsqlDbType.Interval) { Value = value ?? DBNull.Value };
 			}
 
 			return base.CreateParameter(command, parameterName, type, value);

--- a/tests/Shaolinq.Tests/TestModel/ObjectWithManyTypes.cs
+++ b/tests/Shaolinq.Tests/TestModel/ObjectWithManyTypes.cs
@@ -54,6 +54,9 @@ namespace Shaolinq.Tests.TestModel
 		public abstract Sex Enum { get; set; }
 
 		[PersistedMember]
+		public abstract Sex? NullableEnum { get; set; }
+
+		[PersistedMember]
 		public abstract DateTime? NullableDateTime { get; set; }
 
 		[PersistedMember]

--- a/tests/Shaolinq.Tests/TestModel/Sex.cs
+++ b/tests/Shaolinq.Tests/TestModel/Sex.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2007-2016 Thong Nguyen (tumtumtum@gmail.com)
+
 namespace Shaolinq.Tests.TestModel
 {
 	public enum Sex : short

--- a/tests/Shaolinq.Tests/TypeTests.cs
+++ b/tests/Shaolinq.Tests/TypeTests.cs
@@ -85,6 +85,7 @@ namespace Shaolinq.Tests
 				TimeSpan.MinValue ,
 				Sex.Male,
 				null,
+				null,
 				Encoding.UTF8.GetBytes("Hi Kitty Kat 😻😻😻"));
 		}
 
@@ -115,6 +116,7 @@ namespace Shaolinq.Tests
 				Truncate(this.MaxDateTime, TimeSpan.FromMilliseconds(1)),
 				TimeSpan.FromDays(1) + TimeSpan.FromSeconds(1),
 				Sex.Female,
+				Sex.Female,
 				Truncate(this.MaxDateTime, TimeSpan.FromMilliseconds(1)),
 				Encoding.UTF8.GetBytes("Hi Kitty Kat 😻😻😻"));
 		}
@@ -137,6 +139,7 @@ namespace Shaolinq.Tests
 				true,
 				Truncate(DateTime.UtcNow, TimeSpan.FromMilliseconds(1)),
 				TimeSpan.FromHours(24),
+				Sex.Female,
 				Sex.Female,
 				null,
 				Encoding.UTF8.GetBytes("Hi Kitty Kat 😻😻😻"));
@@ -168,6 +171,7 @@ namespace Shaolinq.Tests
 				Truncate(DateTime.UtcNow, TimeSpan.FromMilliseconds(1)),
 				TimeSpan.FromMilliseconds(1),
 				Sex.Female,
+				Sex.Male,
 				Truncate(DateTime.UtcNow, TimeSpan.FromMilliseconds(1)),
 				Encoding.UTF8.GetBytes("\0x0\0x0\0x1"));
 		}
@@ -188,6 +192,7 @@ namespace Shaolinq.Tests
 			DateTime dateTime,
 			TimeSpan timeSpan,
 			Sex @enum,
+			Sex? nullableEnum,
 			DateTime? nullableDateTime,
 			byte[] byteArray
 		)
@@ -213,6 +218,7 @@ namespace Shaolinq.Tests
 				subject.DateTime = dateTime;
 				subject.TimeSpan = timeSpan;
 				subject.Enum = @enum;
+				subject.NullableEnum = nullableEnum;
 				subject.NullableDateTime = nullableDateTime;
 				subject.ByteArray = byteArray;
 
@@ -271,6 +277,7 @@ namespace Shaolinq.Tests
 				this.AssertDateTime(dbObj.DateTime, dateTime);
 				Assert.That(Abs(dbObj.TimeSpan - timeSpan), Is.LessThan(this.timespanEpsilon));
 				Assert.That(dbObj.Enum, Is.EqualTo(@enum));
+				Assert.That(dbObj.NullableEnum, Is.EqualTo(nullableEnum));
 				AssertNullable(dbObj.NullableDateTime, nullableDateTime, this.AssertDateTime);
 				Assert.That(dbObj.ByteArray, Is.EqualTo(byteArray));
 			}


### PR DESCRIPTION
Fix for `Parameter @shaolinqParamX must be set` error by Npgsql validator due to passing `null` instead of `DBNull.Value` when storing null enum values.