### PR TITLE
Changes to allow AsyncRewriter to work in VS2017

### DIFF
--- a/nuspec/Shaolinq.AsyncRewriter.props
+++ b/nuspec/Shaolinq.AsyncRewriter.props
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="AsyncRewriterTask" AssemblyFile="$(MSBuildThisFileDirectory)..\lib\net452\Shaolinq.AsyncRewriter.dll" />
+  <UsingTask TaskName="AsyncRewriterTask" AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Shaolinq.AsyncRewriter.dll" />
 </Project>

--- a/src/Shaolinq.AsyncRewriter/AsyncRewriterTask.cs
+++ b/src/Shaolinq.AsyncRewriter/AsyncRewriterTask.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) 2007-2017 Thong Nguyen (tumtumtum@gmail.com)
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Build.Framework;
 
 namespace Shaolinq.AsyncRewriter
@@ -22,67 +20,9 @@ namespace Shaolinq.AsyncRewriter
 		public bool DontWriteIfNoChanges { get; set; }
 
 		private readonly Rewriter rewriter;
-		
-		private static IEnumerable<string> GetDlls(string parentDirectory)
-		{
-			foreach (var file in Directory.GetFiles(parentDirectory, "*.dll"))
-			{
-				yield return file;
-			}
 
-			foreach (var directory in Directory.GetDirectories(parentDirectory))
-			{
-				foreach (var file in GetDlls(Path.Combine(parentDirectory, directory)))
-				{
-					yield return file;
-				}
-			}
-		}
-		
 		public AsyncRewriterTask()
 		{
-			var assemblyPath = this.GetType().Assembly.Location;
-			
-			var components =
-				Path.GetDirectoryName(assemblyPath)
-				.Split(Path.DirectorySeparatorChar)
-				.Reverse()
-				.SkipWhile(c => !c.Equals("packages", StringComparison.InvariantCultureIgnoreCase))
-				.Reverse()
-				.ToList();
-
-			var path = string.Join(Path.DirectorySeparatorChar.ToString(), components);
-
-			if (path != "")
-			{
-				var pathsByFileName = new Dictionary<string, string>();
-
-				foreach (var value in GetDlls(path))
-				{
-					var fileName = Path.GetFileName(value);
-
-					if (fileName != null)
-					{
-						pathsByFileName[fileName] = value;
-					}
-				}
-
-				AppDomain.CurrentDomain.AssemblyResolve += (sender, e) =>
-				{
-					var fileName = e.Name.Split(',')[0] + ".dll";
-
-					if (pathsByFileName.TryGetValue(fileName, out path))
-					{
-						if (File.Exists(path))
-						{
-							return Assembly.LoadFrom(path);
-						}
-					}
-
-					return null;
-				};
-			}
-
 			this.rewriter = new Rewriter();
 		}
 

--- a/src/Shaolinq.AsyncRewriter/Shaolinq.AsyncRewriter.csproj
+++ b/src/Shaolinq.AsyncRewriter/Shaolinq.AsyncRewriter.csproj
@@ -33,20 +33,13 @@
     <DocumentationFile>bin\Release\Shaolinq.AsyncRewriter.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Activities.Build" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.2.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.2.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -55,15 +48,10 @@
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Shaolinq.AsyncRewriter/packages.config
+++ b/src/Shaolinq.AsyncRewriter/packages.config
@@ -1,9 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net452" />
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.2" targetFramework="net452" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />

--- a/src/Shaolinq.ExpressionWriter/Shaolinq.ExpressionWriter.csproj
+++ b/src/Shaolinq.ExpressionWriter/Shaolinq.ExpressionWriter.csproj
@@ -36,13 +36,11 @@
     <Reference Include="Microsoft.Activities.Build" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.2.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.2.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>

--- a/src/Shaolinq.ExpressionWriter/packages.config
+++ b/src/Shaolinq.ExpressionWriter/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.2" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
   <package id="Platform.NET" version="1.2.1.288" targetFramework="net452" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />

--- a/tests/Shaolinq.AsyncRewriter.Tests/Shaolinq.AsyncRewriter.Tests.csproj
+++ b/tests/Shaolinq.AsyncRewriter.Tests/Shaolinq.AsyncRewriter.Tests.csproj
@@ -32,13 +32,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\Microsoft.CodeAnalysis.Common.1.2.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\Microsoft.CodeAnalysis.CSharp.1.2.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\src\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>

--- a/tests/Shaolinq.AsyncRewriter.Tests/packages.config
+++ b/tests/Shaolinq.AsyncRewriter.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.2" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />


### PR DESCRIPTION
Package Shaolinq.AsyncRewriter DLLs and dependencies as tools.

This means we also don't end up referencing Shaolinq.AsyncRewriter in consuming packages.