### PR TITLE
Add test case for picking up Async methods declared in base classes or interfaces

### DIFF
--- a/tests/Shaolinq.AsyncRewriter.Tests/AsyncRewriterTests.cs
+++ b/tests/Shaolinq.AsyncRewriter.Tests/AsyncRewriterTests.cs
@@ -27,6 +27,7 @@ namespace Shaolinq.AsyncRewriter.Tests
 			yield return GetTestCaseData("Expression body", "TestExpressionBody.cs");
 			yield return GetTestCaseData("Attribute on class", "TestAttributeOnClass.cs");
 			yield return GetTestCaseData("Language features", "LanguageFeatures.cs");
+			yield return GetTestCaseData("Nested async methods", "NestedAsync.cs");
 		}
 
 		private static TestCaseData GetTestCaseData(string name, params string[] inputFiles)

--- a/tests/Shaolinq.AsyncRewriter.Tests/RewriteTests/NestedAsync.cs
+++ b/tests/Shaolinq.AsyncRewriter.Tests/RewriteTests/NestedAsync.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Shaolinq.AsyncRewriter.Tests.RewriteTests
+{
+	public interface IThing : IThingAsync
+	{
+		void DoSomethingNested();
+
+		void DoSomethingNotNested();
+		Task DoSomethingNotNestedAsync();
+	}
+
+	public interface IThingAsync
+	{
+		Task DoSomethingNestedAsync();
+	}
+
+	public class Thing : IThing
+	{
+		public void DoSomethingNested()
+		{
+		}
+
+		public async Task DoSomethingNestedAsync()
+		{
+		}
+
+		public void DoSomethingNotNested()
+		{
+		}
+
+		public async Task DoSomethingNotNestedAsync()
+		{
+		}
+	}
+
+	public class WidgetAsync
+	{
+		public async Task DoSomethingNestedAsync()
+		{
+		}
+	}
+
+	public class Widget : WidgetAsync
+	{
+		public void DoSomethingNested()
+		{
+		}
+
+		public void DoSomethingNotNested()
+		{
+		}
+
+		public async Task DoSomethingNotNestedAsync()
+		{
+		}
+	}
+
+	public partial class NestedAsync
+	{
+		private IThing iThing;
+		private Thing thing;
+		private Widget widget;
+
+		[RewriteAsync]
+		public void Foo()
+		{
+			iThing.DoSomethingNested();
+			iThing.DoSomethingNotNested();
+
+			thing.DoSomethingNested();
+			thing.DoSomethingNotNested();
+
+			widget.DoSomethingNested();
+			widget.DoSomethingNotNested();
+		}
+	}
+}

--- a/tests/Shaolinq.AsyncRewriter.Tests/Shaolinq.AsyncRewriter.Tests.csproj
+++ b/tests/Shaolinq.AsyncRewriter.Tests/Shaolinq.AsyncRewriter.Tests.csproj
@@ -62,6 +62,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsyncRewriterTests.cs" />
+    <Content Include="RewriteTests\NestedAsync.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="RewriteTests\LanguageFeatures.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Currently not picking up async methods declared in base classes or interfaces

```csharp
private IThing iThing;
private Thing thing;
private Widget widget;

[RewriteAsync]
public void Foo()
{
	iThing.DoSomethingNested();
	iThing.DoSomethingNotNested();

	thing.DoSomethingNested();
	thing.DoSomethingNotNested();

	widget.DoSomethingNested();
	widget.DoSomethingNotNested();
}
```
becomes
```csharp
public async Task FooAsync(CancellationToken cancellationToken)
{
	iThing.DoSomethingNested(); // should be async
	await iThing.DoSomethingNotNestedAsync().ConfigureAwait(false);
	await thing.DoSomethingNestedAsync().ConfigureAwait(false);
	await thing.DoSomethingNotNestedAsync().ConfigureAwait(false);
	widget.DoSomethingNested(); // should be async
	await widget.DoSomethingNotNestedAsync().ConfigureAwait(false);
}
```