### PR TITLE
AsyncRewriter ambiguous namespaces test

### DIFF
--- a/tests/Shaolinq.AsyncRewriter.Tests/AsyncRewriterTests.cs
+++ b/tests/Shaolinq.AsyncRewriter.Tests/AsyncRewriterTests.cs
@@ -18,6 +18,7 @@ namespace Shaolinq.AsyncRewriter.Tests
 	{
 		private static IEnumerable<TestCaseData> GetTestCases()
 		{
+			yield return GetTestCaseData("AmbiguousNamespace", "AmbiguousNamespace.cs", "AmbiguousNamespaceClasses.cs");
 			yield return GetTestCaseData("AmbiguousReference", "AmbiguousReference.cs");
 			yield return GetTestCaseData("Rewrite", "Foo.cs", "Bar.cs");
 			yield return GetTestCaseData("Generic Constraints", "IQuery.cs");

--- a/tests/Shaolinq.AsyncRewriter.Tests/RewriteTests/AmbiguousNamespace.cs
+++ b/tests/Shaolinq.AsyncRewriter.Tests/RewriteTests/AmbiguousNamespace.cs
@@ -14,6 +14,20 @@ namespace Something.AsyncRewriter.Tests.RewriteTests
 			TestOtherFoo(otherFoo);
 			TestSomethingOtherFoo(somethingOtherFoo);
 
+			/*
+			 This *should* output:
+			 
+			 Other.Foo.Bar
+			 Something.Other.Foo.Bar
+			 
+			 But currently AsyncRewriter messes up the namespaces and it outputs:
+
+			 Something.Other.Foo.Bar
+			 Something.Other.Foo.Bar
+			 
+			 If you change the commented lines in the methods below, it instead won't compile due to the method 'OtherBar' not being found in 'TestOtherFoo()'
+			*/
+
 			return 0;
 		}
 

--- a/tests/Shaolinq.AsyncRewriter.Tests/RewriteTests/AmbiguousNamespace.cs
+++ b/tests/Shaolinq.AsyncRewriter.Tests/RewriteTests/AmbiguousNamespace.cs
@@ -1,0 +1,34 @@
+﻿using Other;
+using Shaolinq.AsyncRewriter.Tests;
+
+namespace Something.AsyncRewriter.Tests.RewriteTests
+{
+	public partial class AmbiguousNamespace
+	{
+		[RewriteAsync]
+		public static int Main()
+		{
+			var otherFoo = new Foo();
+			var somethingOtherFoo = new Something.Other.Foo();
+
+			TestOtherFoo(otherFoo);
+			TestSomethingOtherFoo(somethingOtherFoo);
+
+			return 0;
+		}
+
+		[RewriteAsync]
+		public static void TestOtherFoo(Foo foo) // Other.Foo
+		{
+			foo.Bar();
+			//foo.OtherBar();
+		}
+
+		[RewriteAsync]
+		public static void TestSomethingOtherFoo(Other.Foo foo) // Something.Other.Foo
+		{
+			foo.Bar();
+			//foo.SomethingOtherBar();
+		} 
+	}
+}

--- a/tests/Shaolinq.AsyncRewriter.Tests/RewriteTests/AmbiguousNamespaceClasses.cs
+++ b/tests/Shaolinq.AsyncRewriter.Tests/RewriteTests/AmbiguousNamespaceClasses.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Shaolinq.AsyncRewriter.Tests;
+
+namespace Other
+{
+	public partial class Foo
+	{
+		[RewriteAsync]
+		public void Bar()
+		{
+			Console.WriteLine("Other.Foo.Bar");
+		}
+
+		[RewriteAsync]
+		public void OtherBar()
+		{
+			Console.WriteLine("Other.Foo.OtherBar");
+		}
+	}
+}
+
+namespace Something.Other
+{
+	public partial class Foo
+	{
+		[RewriteAsync]
+		public void Bar()
+		{
+			Console.WriteLine("Something.Other.Foo.Bar");
+		}
+
+		[RewriteAsync]
+		public void SomethingOtherBar()
+		{
+			Console.WriteLine("Something.Other.Foo.SomethingOtherBar");
+		}
+	}
+}

--- a/tests/Shaolinq.AsyncRewriter.Tests/Shaolinq.AsyncRewriter.Tests.csproj
+++ b/tests/Shaolinq.AsyncRewriter.Tests/Shaolinq.AsyncRewriter.Tests.csproj
@@ -122,6 +122,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsyncRewriterTests.cs" />
+    <None Include="RewriteTests\AmbiguousNamespaceClasses.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="RewriteTests\AmbiguousNamespace.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="RewriteTests\GenericMethods.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
It's possible to have namespaces structured such that AsyncRewriter generates code that prefers the "other" namespace, resulting in either the code not compiling, or if there is a method with a matching signature, the wrong method being called.

This MR has a test demonstrating the situation.