### PR TITLE
Data access hook changes

### DIFF
--- a/src/Shaolinq/DataAccessModel+Hooks.cs
+++ b/src/Shaolinq/DataAccessModel+Hooks.cs
@@ -143,34 +143,34 @@ namespace Shaolinq
 			return CallHooksAsync(hook => hook.AfterSubmitAsync(context, cancellationToken));
 		}
 
-		void IDataAccessModelInternal.OnHookBeforeRollback()
+		void IDataAccessModelInternal.OnHookBeforeRollback(DataAccessModelHookRollbackContext context)
 		{
-			CallHooks(hook => hook.BeforeRollback());
+			CallHooks(hook => hook.BeforeRollback(context));
 		}
 
-		Task IDataAccessModelInternal.OnHookBeforeRollbackAsync()
+		Task IDataAccessModelInternal.OnHookBeforeRollbackAsync(DataAccessModelHookRollbackContext context)
 		{
-			return ((IDataAccessModelInternal)this).OnHookBeforeRollbackAsync(CancellationToken.None);
+			return ((IDataAccessModelInternal)this).OnHookBeforeRollbackAsync(context, CancellationToken.None);
 		}
 
-		Task IDataAccessModelInternal.OnHookBeforeRollbackAsync(CancellationToken cancellationToken)
+		Task IDataAccessModelInternal.OnHookBeforeRollbackAsync(DataAccessModelHookRollbackContext context, CancellationToken cancellationToken)
 		{
-			return CallHooksAsync(hook => hook.BeforeRollbackAsync(cancellationToken));
+			return CallHooksAsync(hook => hook.BeforeRollbackAsync(context, cancellationToken));
 		}
 
-		void IDataAccessModelInternal.OnHookAfterRollback()
+		void IDataAccessModelInternal.OnHookAfterRollback(DataAccessModelHookRollbackContext context)
 		{
-			CallHooks(hook => hook.AfterRollback());
+			CallHooks(hook => hook.AfterRollback(context));
 		}
 
-		Task IDataAccessModelInternal.OnHookAfterRollbackAsync()
+		Task IDataAccessModelInternal.OnHookAfterRollbackAsync(DataAccessModelHookRollbackContext context)
 		{
-			return ((IDataAccessModelInternal)this).OnHookAfterRollbackAsync(CancellationToken.None);
+			return ((IDataAccessModelInternal)this).OnHookAfterRollbackAsync(context, CancellationToken.None);
 		}
 
-		Task IDataAccessModelInternal.OnHookAfterRollbackAsync(CancellationToken cancellationToken)
+		Task IDataAccessModelInternal.OnHookAfterRollbackAsync(DataAccessModelHookRollbackContext context, CancellationToken cancellationToken)
 		{
-			return CallHooksAsync(hook => hook.AfterRollbackAsync(cancellationToken));
+			return CallHooksAsync(hook => hook.AfterRollbackAsync(context, cancellationToken));
 		}
 
 		private void CallHooks(Action<IDataAccessModelHook> hookAction)

--- a/src/Shaolinq/DataAccessModel+Hooks.cs
+++ b/src/Shaolinq/DataAccessModel+Hooks.cs
@@ -80,15 +80,7 @@ namespace Shaolinq
 		
 		void IDataAccessModelInternal.OnHookCreate(DataAccessObject obj)
 		{
-			var localHooks = this.hooks;
-
-			if (localHooks != null)
-			{
-				foreach (var hook in localHooks)
-				{
-					hook.Create(obj);
-				}
-			}
+			CallHooks(hook => hook.Create(obj));
 		}
 
 		Task IDataAccessModelInternal.OnHookCreateAsync(DataAccessObject dataAccessObject)
@@ -98,34 +90,17 @@ namespace Shaolinq
 
 		Task IDataAccessModelInternal.OnHookCreateAsync(DataAccessObject dataAccessObject, CancellationToken cancellationToken)
 		{
-			var localHooks = this.hooks;
-			var tasks = new List<Task>();
-	
-			if (localHooks != null)
+			return CallHooksAsync(hook =>
 			{
-				foreach (var hook in localHooks)
-				{
-					var task = hook.CreateAsync(dataAccessObject, cancellationToken);
-					
-					task.ConfigureAwait(false);
-					tasks.Add(task);
-				}
-			}
-
-			return Task.WhenAll(tasks);
+				var task = hook.CreateAsync(dataAccessObject, cancellationToken);
+				task.ConfigureAwait(false);
+				return task;
+			});
 		}
 		
 		void IDataAccessModelInternal.OnHookRead(DataAccessObject obj)
 		{
-			var localHooks = this.hooks;
-
-			if (localHooks != null)
-			{
-				foreach (var hook in localHooks)
-				{
-					hook.Read(obj);
-				}
-			}
+			CallHooks(hook => hook.Read(obj));
 		}
 
 		Task IDataAccessModelInternal.OnHookReadAsync(DataAccessObject dataAccessObject)
@@ -135,28 +110,12 @@ namespace Shaolinq
 
 		Task IDataAccessModelInternal.OnHookReadAsync(DataAccessObject dataAccessObject, CancellationToken cancellationToken)
 		{
-			var localHooks = this.hooks;
-			var tasks = new List<Task>();
-	
-			if (localHooks != null)
-			{
-				tasks.AddRange(localHooks.Select(hook => hook.ReadAsync(dataAccessObject, cancellationToken)));
-			}
-
-			return Task.WhenAll(tasks);
+			return CallHooksAsync(hook => hook.ReadAsync(dataAccessObject, cancellationToken));
 		}
 		
 		void IDataAccessModelInternal.OnHookBeforeSubmit(DataAccessModelHookSubmitContext context)
 		{
-			var localHooks = this.hooks;
-
-			if (localHooks != null)
-			{
-				foreach (var hook in localHooks)
-				{
-					hook.BeforeSubmit(context);
-				}
-			}
+			CallHooks(hook => hook.BeforeSubmit(context));
 		}
 		
 		Task IDataAccessModelInternal.OnHookBeforeSubmitAsync(DataAccessModelHookSubmitContext context)
@@ -166,28 +125,12 @@ namespace Shaolinq
 
 		Task IDataAccessModelInternal.OnHookBeforeSubmitAsync(DataAccessModelHookSubmitContext context, CancellationToken cancellationToken)
 		{
-			var localHooks = this.hooks;
-			var tasks = new List<Task>();
-	
-			if (localHooks != null)
-			{
-				tasks.AddRange(localHooks.Select(hook => hook.BeforeSubmitAsync(context, cancellationToken)));
-			}
-
-			return Task.WhenAll(tasks);
+			return CallHooksAsync(hook => hook.BeforeSubmitAsync(context, cancellationToken));
 		}
 
 		void IDataAccessModelInternal.OnHookAfterSubmit(DataAccessModelHookSubmitContext context)
 		{
-			var localHooks = this.hooks;
-
-			if (localHooks != null)
-			{
-				foreach (var hook in localHooks)
-				{
-					hook.AfterSubmit(context);
-				}
-			}
+			CallHooks(hook => hook.AfterSubmit(context));
 		}
 
 		Task IDataAccessModelInternal.OnHookAfterSubmitAsync(DataAccessModelHookSubmitContext context)
@@ -197,15 +140,33 @@ namespace Shaolinq
 
 		Task IDataAccessModelInternal.OnHookAfterSubmitAsync(DataAccessModelHookSubmitContext context, CancellationToken cancellationToken)
 		{
+			return CallHooksAsync(hook => hook.AfterSubmitAsync(context, cancellationToken));
+		}
+
+		private void CallHooks(Action<IDataAccessModelHook> hookAction)
+		{
 			var localHooks = this.hooks;
-			var tasks = new List<Task>();
-	
+
 			if (localHooks != null)
 			{
-				tasks.AddRange(localHooks.Select(hook => hook.AfterSubmitAsync(context, cancellationToken)));
+				foreach (var hook in localHooks)
+				{
+					hookAction(hook);
+				}
+			}
+		}
+
+		private async Task CallHooksAsync(Func<IDataAccessModelHook, Task> hookFunc)
+		{
+			var localHooks = this.hooks;
+			var tasks = new List<Task>();
+
+			if (localHooks != null)
+			{
+				tasks.AddRange(localHooks.Select(hookFunc));
 			}
 
-			return Task.WhenAll(tasks);
+			await Task.WhenAll(tasks);
 		}
 	}
 }

--- a/src/Shaolinq/DataAccessModel+Hooks.cs
+++ b/src/Shaolinq/DataAccessModel+Hooks.cs
@@ -105,7 +105,7 @@ namespace Shaolinq
 
 		Task IDataAccessModelInternal.OnHookReadAsync(DataAccessObject dataAccessObject)
 		{
-			return ((IDataAccessModelInternal)this).OnHookCreateAsync(dataAccessObject, CancellationToken.None);
+			return ((IDataAccessModelInternal)this).OnHookReadAsync(dataAccessObject, CancellationToken.None);
 		}
 
 		Task IDataAccessModelInternal.OnHookReadAsync(DataAccessObject dataAccessObject, CancellationToken cancellationToken)
@@ -135,7 +135,7 @@ namespace Shaolinq
 
 		Task IDataAccessModelInternal.OnHookAfterSubmitAsync(DataAccessModelHookSubmitContext context)
 		{
-			return ((IDataAccessModelInternal)this).OnHookBeforeSubmitAsync(context, CancellationToken.None);
+			return ((IDataAccessModelInternal)this).OnHookAfterSubmitAsync(context, CancellationToken.None);
 		}
 
 		Task IDataAccessModelInternal.OnHookAfterSubmitAsync(DataAccessModelHookSubmitContext context, CancellationToken cancellationToken)
@@ -159,14 +159,11 @@ namespace Shaolinq
 		private async Task CallHooksAsync(Func<IDataAccessModelHook, Task> hookFunc)
 		{
 			var localHooks = this.hooks;
-			var tasks = new List<Task>();
 
 			if (localHooks != null)
 			{
-				tasks.AddRange(localHooks.Select(hookFunc));
+				await Task.WhenAll(localHooks.Select(hookFunc));
 			}
-
-			await Task.WhenAll(tasks);
 		}
 	}
 }

--- a/src/Shaolinq/DataAccessModel+Hooks.cs
+++ b/src/Shaolinq/DataAccessModel+Hooks.cs
@@ -143,6 +143,36 @@ namespace Shaolinq
 			return CallHooksAsync(hook => hook.AfterSubmitAsync(context, cancellationToken));
 		}
 
+		void IDataAccessModelInternal.OnHookBeforeRollback()
+		{
+			CallHooks(hook => hook.BeforeRollback());
+		}
+
+		Task IDataAccessModelInternal.OnHookBeforeRollbackAsync()
+		{
+			return ((IDataAccessModelInternal)this).OnHookBeforeRollbackAsync(CancellationToken.None);
+		}
+
+		Task IDataAccessModelInternal.OnHookBeforeRollbackAsync(CancellationToken cancellationToken)
+		{
+			return CallHooksAsync(hook => hook.BeforeRollbackAsync(cancellationToken));
+		}
+
+		void IDataAccessModelInternal.OnHookAfterRollback()
+		{
+			CallHooks(hook => hook.AfterRollback());
+		}
+
+		Task IDataAccessModelInternal.OnHookAfterRollbackAsync()
+		{
+			return ((IDataAccessModelInternal)this).OnHookAfterRollbackAsync(CancellationToken.None);
+		}
+
+		Task IDataAccessModelInternal.OnHookAfterRollbackAsync(CancellationToken cancellationToken)
+		{
+			return CallHooksAsync(hook => hook.AfterRollbackAsync(cancellationToken));
+		}
+
 		private void CallHooks(Action<IDataAccessModelHook> hookAction)
 		{
 			var localHooks = this.hooks;

--- a/src/Shaolinq/DataAccessModel.cs
+++ b/src/Shaolinq/DataAccessModel.cs
@@ -747,6 +747,8 @@ namespace Shaolinq
 			retvalInternal.FinishedInitializing();
 			retvalInternal.SubmitToCache();
 
+			((IDataAccessModelInternal)this).OnHookCreate(retval);
+
 			return retval;
 		}
 
@@ -784,6 +786,8 @@ namespace Shaolinq
 					.SetPrimaryKeys(objectPropertyAndValues)
 					.FinishedInitializing()
 					.SubmitToCache();
+
+				((IDataAccessModelInternal)this).OnHookCreate(retval);
 
 				return retval;
 			}

--- a/src/Shaolinq/DataAccessModel.cs
+++ b/src/Shaolinq/DataAccessModel.cs
@@ -356,8 +356,6 @@ namespace Shaolinq
 					.FinishedInitializing()
 					.SubmitToCache();
 
-				((IDataAccessModelInternal)this).OnHookCreate(retval);
-
 				return retval;
 			}
 		}
@@ -387,8 +385,6 @@ namespace Shaolinq
 					.ResetModified()
 					.FinishedInitializing()
 					.SubmitToCache();
-
-				((IDataAccessModelInternal)this).OnHookCreate(retval);
 
 				return retval;
 			}

--- a/src/Shaolinq/DataAccessModelHookBase.cs
+++ b/src/Shaolinq/DataAccessModelHookBase.cs
@@ -38,12 +38,12 @@ namespace Shaolinq
 		}
 
 		[RewriteAsync]
-		public virtual void BeforeRollback()
+		public virtual void BeforeRollback(DataAccessModelHookRollbackContext context)
 		{
 		}
 
 		[RewriteAsync]
-		public virtual void AfterRollback()
+		public virtual void AfterRollback(DataAccessModelHookRollbackContext context)
 		{
 		}
 	}

--- a/src/Shaolinq/DataAccessModelHookBase.cs
+++ b/src/Shaolinq/DataAccessModelHookBase.cs
@@ -36,5 +36,15 @@ namespace Shaolinq
 		public virtual void AfterSubmit(DataAccessModelHookSubmitContext context)
 		{
 		}
+
+		[RewriteAsync]
+		public virtual void BeforeRollback()
+		{
+		}
+
+		[RewriteAsync]
+		public virtual void AfterRollback()
+		{
+		}
 	}
 }

--- a/src/Shaolinq/DataAccessModelHookContextBase.cs
+++ b/src/Shaolinq/DataAccessModelHookContextBase.cs
@@ -1,0 +1,15 @@
+﻿namespace Shaolinq
+{
+	public abstract class DataAccessModelHookContextBase
+	{
+		protected readonly TransactionContext transactionContext;
+
+		public string TransactionContextId => transactionContext?.TransactionContextId;
+		public string DataAccessTransactionId => transactionContext?.DataAccessTransaction?.DataAccessTransactionId;
+
+		internal DataAccessModelHookContextBase(TransactionContext transactionContext)
+		{
+			this.transactionContext = transactionContext;
+		}
+	}
+}

--- a/src/Shaolinq/DataAccessModelHookRollbackContext.cs
+++ b/src/Shaolinq/DataAccessModelHookRollbackContext.cs
@@ -1,0 +1,9 @@
+﻿namespace Shaolinq
+{
+	public class DataAccessModelHookRollbackContext : DataAccessModelHookContextBase
+	{
+		public DataAccessModelHookRollbackContext(TransactionContext transactionContext) : base(transactionContext)
+		{
+		}
+	}
+}

--- a/src/Shaolinq/DataAccessModelHookSubmitContext.cs
+++ b/src/Shaolinq/DataAccessModelHookSubmitContext.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Shaolinq
 {
-	public class DataAccessModelHookSubmitContext
+	public class DataAccessModelHookSubmitContext : DataAccessModelHookContextBase
 	{
 		public bool IsFlush { get; }
 		public bool IsCommit => !IsFlush;
@@ -18,7 +18,8 @@ namespace Shaolinq
 
 		private readonly DataAccessObjectDataContext dataContext;
 
-		internal DataAccessModelHookSubmitContext(DataAccessObjectDataContext dataContext, bool isFlush)
+		internal DataAccessModelHookSubmitContext(TransactionContext transactionContext, DataAccessObjectDataContext dataContext, bool isFlush)
+			: base(transactionContext)
 		{
 			this.dataContext = dataContext;
 			this.IsFlush = isFlush;

--- a/src/Shaolinq/DataAccessModelHookSubmitContext.cs
+++ b/src/Shaolinq/DataAccessModelHookSubmitContext.cs
@@ -9,6 +9,7 @@ namespace Shaolinq
 	public class DataAccessModelHookSubmitContext
 	{
 		public bool IsFlush { get; }
+		public bool IsCommit => !IsFlush;
 		public Exception Exception { get; internal set; }
 
 		public IEnumerable<DataAccessObject> New => this.dataContext.cachesByType.SelectMany(cache => cache.Value.GetNewObjects());

--- a/src/Shaolinq/DataAccessObjectDataContext.cs
+++ b/src/Shaolinq/DataAccessObjectDataContext.cs
@@ -220,7 +220,7 @@ namespace Shaolinq
 				cache.Value.AssertObjectsAreReadyForCommit();
 			}
 			
-			var context = new DataAccessModelHookSubmitContext(this, forFlush);
+			var context = new DataAccessModelHookSubmitContext(commandsContext.TransactionContext, this, forFlush);
 
 			try
 			{

--- a/src/Shaolinq/DataAccessTransaction.cs
+++ b/src/Shaolinq/DataAccessTransaction.cs
@@ -54,7 +54,7 @@ namespace Shaolinq
 		private bool isfinishing;
 
 		internal TimeSpan timeout;
-		internal Transaction SystemTransaction { get; set; }
+		internal Transaction SystemTransaction { get; }
 		internal bool HasSystemTransaction => this.SystemTransaction != null;
 		internal Dictionary<DataAccessModel, TransactionContext> transactionContextsByDataAccessModel;
 		internal bool aborted;
@@ -62,6 +62,7 @@ namespace Shaolinq
 		internal bool systemTransactionCompleted;
 		internal TransactionStatus systemTransactionStatus;
 
+		public string DataAccessTransactionId { get; }
 		public DataAccessIsolationLevel IsolationLevel { get; }
 		public IEnumerable<DataAccessModel> ParticipatingDataAccessModels => this.transactionContextsByDataAccessModel?.Keys ?? Enumerable.Empty<DataAccessModel>();
 
@@ -93,6 +94,9 @@ namespace Shaolinq
 					Dispose();
 				};
 			}
+
+			this.DataAccessTransactionId = this.SystemTransaction?.TransactionInformation.LocalIdentifier ??
+			                               Guid.NewGuid().ToString("N");
 		}
 
 		public void AddTransactionContext(TransactionContext context)

--- a/src/Shaolinq/DataAccessTransaction.cs
+++ b/src/Shaolinq/DataAccessTransaction.cs
@@ -140,7 +140,14 @@ namespace Shaolinq
 			{
 				foreach (var transactionContext in this.transactionContextsByDataAccessModel.Values)
 				{
-					ActionUtils.IgnoreExceptions(() => transactionContext.Rollback());
+					try
+					{
+						transactionContext.Rollback();
+					}
+					catch
+					{
+						// ignored
+					}
 				}
 			}
 		}

--- a/src/Shaolinq/DataAccessTransaction.cs
+++ b/src/Shaolinq/DataAccessTransaction.cs
@@ -154,7 +154,7 @@ namespace Shaolinq
 
 			this.isfinishing = true;
 
-			if (this.transactionContextsByDataAccessModel != null)
+			if (!this.systemTransactionCompleted && this.transactionContextsByDataAccessModel != null)
 			{
 				foreach (var transactionContext in this.transactionContextsByDataAccessModel.Values)
 				{

--- a/src/Shaolinq/GeneratedAsync.cs
+++ b/src/Shaolinq/GeneratedAsync.cs
@@ -525,7 +525,14 @@ namespace Shaolinq
 			{
 				foreach (var transactionContext in this.transactionContextsByDataAccessModel.Values)
 				{
-					ActionUtils.IgnoreExceptions(() => transactionContext.Rollback());
+					try
+					{
+						await transactionContext.RollbackAsync(cancellationToken).ConfigureAwait(false);
+					}
+					catch
+					{
+					// ignored
+					}
 				}
 			}
 		}
@@ -1781,7 +1788,15 @@ namespace Shaolinq.Persistence
 
 		public virtual async Task RollbackAsync(CancellationToken cancellationToken)
 		{
-			ActionUtils.IgnoreExceptions(() => ((IDataAccessModelInternal)this.DataAccessModel).OnHookBeforeRollback());
+			try
+			{
+				await ((IDataAccessModelInternal)this.DataAccessModel).OnHookBeforeRollbackAsync(cancellationToken).ConfigureAwait(false);
+			}
+			catch
+			{
+			// ignored
+			}
+
 			try
 			{
 				if (this.dbTransaction != null)
@@ -1794,7 +1809,14 @@ namespace Shaolinq.Persistence
 			finally
 			{
 				CloseConnection();
-				ActionUtils.IgnoreExceptions(() => ((IDataAccessModelInternal)this.DataAccessModel).OnHookAfterRollback());
+				try
+				{
+					await ((IDataAccessModelInternal)this.DataAccessModel).OnHookAfterRollbackAsync(cancellationToken).ConfigureAwait(false);
+				}
+				catch
+				{
+				// ignored
+				}
 			}
 		}
 	}

--- a/src/Shaolinq/GeneratedAsync.cs
+++ b/src/Shaolinq/GeneratedAsync.cs
@@ -45,6 +45,24 @@ namespace Shaolinq
 		public virtual async Task AfterSubmitAsync(DataAccessModelHookSubmitContext context, CancellationToken cancellationToken)
 		{
 		}
+
+		public virtual Task BeforeRollbackAsync()
+		{
+			return this.BeforeRollbackAsync(CancellationToken.None);
+		}
+
+		public virtual async Task BeforeRollbackAsync(CancellationToken cancellationToken)
+		{
+		}
+
+		public virtual Task AfterRollbackAsync()
+		{
+			return this.AfterRollbackAsync(CancellationToken.None);
+		}
+
+		public virtual async Task AfterRollbackAsync(CancellationToken cancellationToken)
+		{
+		}
 	}
 }
 
@@ -938,7 +956,7 @@ namespace Shaolinq
 		/// </summary>
 		Task BeforeSubmitAsync(DataAccessModelHookSubmitContext context, CancellationToken cancellationToken);
 		/// <summary>
-		/// Called just after changes have been written to thea database
+		/// Called just after changes have been written to the database
 		/// </summary>
 		/// <remarks>
 		/// A transaction is usually committed after this call unless the call is due
@@ -946,13 +964,29 @@ namespace Shaolinq
 		/// </remarks>
 		Task AfterSubmitAsync(DataAccessModelHookSubmitContext context);
 		/// <summary>
-		/// Called just after changes have been written to thea database
+		/// Called just after changes have been written to the database
 		/// </summary>
 		/// <remarks>
 		/// A transaction is usually committed after this call unless the call is due
 		/// to a <see cref = "DataAccessModel.Flush()"/> call
 		/// </remarks>
 		Task AfterSubmitAsync(DataAccessModelHookSubmitContext context, CancellationToken cancellationToken);
+		/// <summary>
+		/// Called just before a transaction is rolled back
+		/// </summary>
+		Task BeforeRollbackAsync();
+		/// <summary>
+		/// Called just before a transaction is rolled back
+		/// </summary>
+		Task BeforeRollbackAsync(CancellationToken cancellationToken);
+		/// <summary>
+		/// Called just after a transaction is rolled back
+		/// </summary>
+		Task AfterRollbackAsync();
+		/// <summary>
+		/// Called just after a transaction is rolled back
+		/// </summary>
+		Task AfterRollbackAsync(CancellationToken cancellationToken);
 	}
 }
 
@@ -976,6 +1010,10 @@ namespace Shaolinq.Persistence
 		Task OnHookBeforeSubmitAsync(DataAccessModelHookSubmitContext context, CancellationToken cancellationToken);
 		Task OnHookAfterSubmitAsync(DataAccessModelHookSubmitContext context);
 		Task OnHookAfterSubmitAsync(DataAccessModelHookSubmitContext context, CancellationToken cancellationToken);
+		Task OnHookBeforeRollbackAsync();
+		Task OnHookBeforeRollbackAsync(CancellationToken cancellationToken);
+		Task OnHookAfterRollbackAsync();
+		Task OnHookAfterRollbackAsync(CancellationToken cancellationToken);
 	}
 }
 
@@ -1743,6 +1781,7 @@ namespace Shaolinq.Persistence
 
 		public virtual async Task RollbackAsync(CancellationToken cancellationToken)
 		{
+			ActionUtils.IgnoreExceptions(() => ((IDataAccessModelInternal)this.DataAccessModel).OnHookBeforeRollback());
 			try
 			{
 				if (this.dbTransaction != null)
@@ -1755,6 +1794,7 @@ namespace Shaolinq.Persistence
 			finally
 			{
 				CloseConnection();
+				ActionUtils.IgnoreExceptions(() => ((IDataAccessModelInternal)this.DataAccessModel).OnHookAfterRollback());
 			}
 		}
 	}

--- a/src/Shaolinq/GeneratedAsync.cs
+++ b/src/Shaolinq/GeneratedAsync.cs
@@ -46,21 +46,21 @@ namespace Shaolinq
 		{
 		}
 
-		public virtual Task BeforeRollbackAsync()
+		public virtual Task BeforeRollbackAsync(DataAccessModelHookRollbackContext context)
 		{
-			return this.BeforeRollbackAsync(CancellationToken.None);
+			return this.BeforeRollbackAsync(context, CancellationToken.None);
 		}
 
-		public virtual async Task BeforeRollbackAsync(CancellationToken cancellationToken)
+		public virtual async Task BeforeRollbackAsync(DataAccessModelHookRollbackContext context, CancellationToken cancellationToken)
 		{
 		}
 
-		public virtual Task AfterRollbackAsync()
+		public virtual Task AfterRollbackAsync(DataAccessModelHookRollbackContext context)
 		{
-			return this.AfterRollbackAsync(CancellationToken.None);
+			return this.AfterRollbackAsync(context, CancellationToken.None);
 		}
 
-		public virtual async Task AfterRollbackAsync(CancellationToken cancellationToken)
+		public virtual async Task AfterRollbackAsync(DataAccessModelHookRollbackContext context, CancellationToken cancellationToken)
 		{
 		}
 	}
@@ -981,19 +981,19 @@ namespace Shaolinq
 		/// <summary>
 		/// Called just before a transaction is rolled back
 		/// </summary>
-		Task BeforeRollbackAsync();
+		Task BeforeRollbackAsync(DataAccessModelHookRollbackContext context);
 		/// <summary>
 		/// Called just before a transaction is rolled back
 		/// </summary>
-		Task BeforeRollbackAsync(CancellationToken cancellationToken);
+		Task BeforeRollbackAsync(DataAccessModelHookRollbackContext context, CancellationToken cancellationToken);
 		/// <summary>
 		/// Called just after a transaction is rolled back
 		/// </summary>
-		Task AfterRollbackAsync();
+		Task AfterRollbackAsync(DataAccessModelHookRollbackContext context);
 		/// <summary>
 		/// Called just after a transaction is rolled back
 		/// </summary>
-		Task AfterRollbackAsync(CancellationToken cancellationToken);
+		Task AfterRollbackAsync(DataAccessModelHookRollbackContext context, CancellationToken cancellationToken);
 	}
 }
 
@@ -1017,10 +1017,10 @@ namespace Shaolinq.Persistence
 		Task OnHookBeforeSubmitAsync(DataAccessModelHookSubmitContext context, CancellationToken cancellationToken);
 		Task OnHookAfterSubmitAsync(DataAccessModelHookSubmitContext context);
 		Task OnHookAfterSubmitAsync(DataAccessModelHookSubmitContext context, CancellationToken cancellationToken);
-		Task OnHookBeforeRollbackAsync();
-		Task OnHookBeforeRollbackAsync(CancellationToken cancellationToken);
-		Task OnHookAfterRollbackAsync();
-		Task OnHookAfterRollbackAsync(CancellationToken cancellationToken);
+		Task OnHookBeforeRollbackAsync(DataAccessModelHookRollbackContext context);
+		Task OnHookBeforeRollbackAsync(DataAccessModelHookRollbackContext context, CancellationToken cancellationToken);
+		Task OnHookAfterRollbackAsync(DataAccessModelHookRollbackContext context);
+		Task OnHookAfterRollbackAsync(DataAccessModelHookRollbackContext context, CancellationToken cancellationToken);
 	}
 }
 
@@ -1788,9 +1788,10 @@ namespace Shaolinq.Persistence
 
 		public virtual async Task RollbackAsync(CancellationToken cancellationToken)
 		{
+			var context = new DataAccessModelHookRollbackContext(this.TransactionContext);
 			try
 			{
-				await ((IDataAccessModelInternal)this.DataAccessModel).OnHookBeforeRollbackAsync(cancellationToken).ConfigureAwait(false);
+				await ((IDataAccessModelInternal)this.DataAccessModel).OnHookBeforeRollbackAsync(context, cancellationToken).ConfigureAwait(false);
 			}
 			catch
 			{
@@ -1811,7 +1812,7 @@ namespace Shaolinq.Persistence
 				CloseConnection();
 				try
 				{
-					await ((IDataAccessModelInternal)this.DataAccessModel).OnHookAfterRollbackAsync(cancellationToken).ConfigureAwait(false);
+					await ((IDataAccessModelInternal)this.DataAccessModel).OnHookAfterRollbackAsync(context, cancellationToken).ConfigureAwait(false);
 				}
 				catch
 				{
@@ -2562,7 +2563,7 @@ namespace Shaolinq
 				cache.Value.AssertObjectsAreReadyForCommit();
 			}
 
-			var context = new DataAccessModelHookSubmitContext(this, forFlush);
+			var context = new DataAccessModelHookSubmitContext(commandsContext.TransactionContext, this, forFlush);
 			try
 			{
 				await ((IDataAccessModelInternal)this.DataAccessModel).OnHookBeforeSubmitAsync(context, cancellationToken).ConfigureAwait(false);

--- a/src/Shaolinq/IDataAccessModelHook.cs
+++ b/src/Shaolinq/IDataAccessModelHook.cs
@@ -52,12 +52,12 @@ namespace Shaolinq
 		/// Called just before a transaction is rolled back
 		/// </summary>
 		[RewriteAsync]
-		void BeforeRollback();
+		void BeforeRollback(DataAccessModelHookRollbackContext context);
 
 		/// <summary>
 		/// Called just after a transaction is rolled back
 		/// </summary>
 		[RewriteAsync]
-		void AfterRollback();
+		void AfterRollback(DataAccessModelHookRollbackContext context);
 	}
 }

--- a/src/Shaolinq/IDataAccessModelHook.cs
+++ b/src/Shaolinq/IDataAccessModelHook.cs
@@ -39,7 +39,7 @@ namespace Shaolinq
 		void BeforeSubmit(DataAccessModelHookSubmitContext context);
 
 		/// <summary>
-		/// Called just after changes have been written to thea database
+		/// Called just after changes have been written to the database
 		/// </summary>
 		/// <remarks>
 		/// A transaction is usually committed after this call unless the call is due
@@ -47,5 +47,17 @@ namespace Shaolinq
 		/// </remarks>
 		[RewriteAsync]
 		void AfterSubmit(DataAccessModelHookSubmitContext context);
+
+		/// <summary>
+		/// Called just before a transaction is rolled back
+		/// </summary>
+		[RewriteAsync]
+		void BeforeRollback();
+
+		/// <summary>
+		/// Called just after a transaction is rolled back
+		/// </summary>
+		[RewriteAsync]
+		void AfterRollback();
 	}
 }

--- a/src/Shaolinq/Persistence/IDataAccessModelInternal.cs
+++ b/src/Shaolinq/Persistence/IDataAccessModelInternal.cs
@@ -23,9 +23,9 @@ namespace Shaolinq.Persistence
 		void OnHookAfterSubmit(DataAccessModelHookSubmitContext context);
 
 		[RewriteAsync]
-		void OnHookBeforeRollback();
+		void OnHookBeforeRollback(DataAccessModelHookRollbackContext context);
 
 		[RewriteAsync]
-		void OnHookAfterRollback();
+		void OnHookAfterRollback(DataAccessModelHookRollbackContext context);
 	}
 }

--- a/src/Shaolinq/Persistence/IDataAccessModelInternal.cs
+++ b/src/Shaolinq/Persistence/IDataAccessModelInternal.cs
@@ -21,5 +21,11 @@ namespace Shaolinq.Persistence
 
 		[RewriteAsync]
 		void OnHookAfterSubmit(DataAccessModelHookSubmitContext context);
+
+		[RewriteAsync]
+		void OnHookBeforeRollback();
+
+		[RewriteAsync]
+		void OnHookAfterRollback();
 	}
 }

--- a/src/Shaolinq/Persistence/SqlTransactionalCommandsContext.cs
+++ b/src/Shaolinq/Persistence/SqlTransactionalCommandsContext.cs
@@ -14,7 +14,7 @@ namespace Shaolinq.Persistence
 	public abstract partial class SqlTransactionalCommandsContext
 		: IDisposable
 	{
-		public TransactionContext TransactionContext { get; set; }
+		public TransactionContext TransactionContext { get; }
 		internal MarsDataReader currentReader;
 
 		private bool disposed;
@@ -256,9 +256,11 @@ namespace Shaolinq.Persistence
 		[RewriteAsync]
 		public virtual void Rollback()
 		{
+			var context = new DataAccessModelHookRollbackContext(this.TransactionContext);
+
 			try
 			{
-				((IDataAccessModelInternal)this.DataAccessModel).OnHookBeforeRollback();
+				((IDataAccessModelInternal)this.DataAccessModel).OnHookBeforeRollback(context);
 			}
 			catch
 			{
@@ -280,7 +282,7 @@ namespace Shaolinq.Persistence
 
 				try
 				{
-					((IDataAccessModelInternal)this.DataAccessModel).OnHookAfterRollback();
+					((IDataAccessModelInternal)this.DataAccessModel).OnHookAfterRollback(context);
 				}
 				catch
 				{

--- a/src/Shaolinq/Persistence/SqlTransactionalCommandsContext.cs
+++ b/src/Shaolinq/Persistence/SqlTransactionalCommandsContext.cs
@@ -256,6 +256,8 @@ namespace Shaolinq.Persistence
 		[RewriteAsync]
 		public virtual void Rollback()
 		{
+			ActionUtils.IgnoreExceptions(() => ((IDataAccessModelInternal)this.DataAccessModel).OnHookBeforeRollback());
+
 			try
 			{
 				if (this.dbTransaction != null)
@@ -268,6 +270,8 @@ namespace Shaolinq.Persistence
 			finally
 			{
 				CloseConnection();
+
+				ActionUtils.IgnoreExceptions(() => ((IDataAccessModelInternal)this.DataAccessModel).OnHookAfterRollback());
 			}
 		}
 

--- a/src/Shaolinq/Persistence/SqlTransactionalCommandsContext.cs
+++ b/src/Shaolinq/Persistence/SqlTransactionalCommandsContext.cs
@@ -21,7 +21,7 @@ namespace Shaolinq.Persistence
 		public bool SupportsAsync { get; protected set; }
 		public IDbConnection DbConnection { get; private set; }
 		public SqlDatabaseContext SqlDatabaseContext { get; }
-		
+
 		protected IDbTransaction dbTransaction;
 		public DataAccessModel DataAccessModel { get; }
 		private readonly bool emulateMultipleActiveResultSets;
@@ -69,7 +69,7 @@ namespace Shaolinq.Persistence
 
 		public IDbDataParameter AddParameter(IDbCommand command, Type type, string name, object value)
 		{
-			var parameter = CreateParameter(command,  name ?? this.parameterIndicatorPrefix + SqlQueryFormatter.ParamNamePrefix + command.Parameters.Count, type, value);
+			var parameter = CreateParameter(command, name ?? this.parameterIndicatorPrefix + SqlQueryFormatter.ParamNamePrefix + command.Parameters.Count, type, value);
 
 			command.Parameters.Add(parameter);
 
@@ -144,25 +144,25 @@ namespace Shaolinq.Persistence
 
 			return parameter;
 		}
-		
+
 		public static IsolationLevel ConvertIsolationLevel(DataAccessIsolationLevel isolationLevel)
 		{
 			switch (isolationLevel)
 			{
-			case DataAccessIsolationLevel.ReadUncommitted:
-				return IsolationLevel.ReadUncommitted;
-			case DataAccessIsolationLevel.Serializable:
-				return IsolationLevel.Serializable;
-			case DataAccessIsolationLevel.ReadCommitted:
-				return IsolationLevel.ReadCommitted;
-			case DataAccessIsolationLevel.Chaos:
-				return IsolationLevel.Chaos;
-			case DataAccessIsolationLevel.RepeatableRead:
-				return IsolationLevel.RepeatableRead;
-			case DataAccessIsolationLevel.Snapshot:
-				return IsolationLevel.Snapshot;
-			default:
-				return IsolationLevel.Unspecified;
+				case DataAccessIsolationLevel.ReadUncommitted:
+					return IsolationLevel.ReadUncommitted;
+				case DataAccessIsolationLevel.Serializable:
+					return IsolationLevel.Serializable;
+				case DataAccessIsolationLevel.ReadCommitted:
+					return IsolationLevel.ReadCommitted;
+				case DataAccessIsolationLevel.Chaos:
+					return IsolationLevel.Chaos;
+				case DataAccessIsolationLevel.RepeatableRead:
+					return IsolationLevel.RepeatableRead;
+				case DataAccessIsolationLevel.Snapshot:
+					return IsolationLevel.Snapshot;
+				default:
+					return IsolationLevel.Unspecified;
 			}
 		}
 
@@ -171,25 +171,25 @@ namespace Shaolinq.Persistence
 			this.TransactionContext = transactionContext;
 
 			try
-		    {
-		        this.DbConnection = dbConnection;
-		        this.SqlDatabaseContext = sqlDatabaseContext;
-		        this.DataAccessModel = sqlDatabaseContext.DataAccessModel;
-			    this.parameterIndicatorPrefix = this.SqlDatabaseContext.SqlDialect.GetSyntaxSymbolString(SqlSyntaxSymbol.ParameterPrefix);
+			{
+				this.DbConnection = dbConnection;
+				this.SqlDatabaseContext = sqlDatabaseContext;
+				this.DataAccessModel = sqlDatabaseContext.DataAccessModel;
+				this.parameterIndicatorPrefix = this.SqlDatabaseContext.SqlDialect.GetSyntaxSymbolString(SqlSyntaxSymbol.ParameterPrefix);
 
 				this.emulateMultipleActiveResultSets = !sqlDatabaseContext.SqlDialect.SupportsCapability(SqlCapability.MultipleActiveResultSets);
 
-		        if (transactionContext?.DataAccessTransaction != null)
-		        {
-		            this.dbTransaction = dbConnection.BeginTransaction(ConvertIsolationLevel(transactionContext.DataAccessTransaction.IsolationLevel));
-		        }
-		    }
-		    catch
-		    {
-		        Dispose(true);
+				if (transactionContext?.DataAccessTransaction != null)
+				{
+					this.dbTransaction = dbConnection.BeginTransaction(ConvertIsolationLevel(transactionContext.DataAccessTransaction.IsolationLevel));
+				}
+			}
+			catch
+			{
+				Dispose(true);
 
-		        throw;
-		    }
+				throw;
+			}
 		}
 
 		~SqlTransactionalCommandsContext()
@@ -203,7 +203,7 @@ namespace Shaolinq.Persistence
 		{
 			var retval = this.DbConnection.CreateCommand();
 
-			 retval.Transaction = this.dbTransaction;
+			retval.Transaction = this.dbTransaction;
 
 			if (this.SqlDatabaseContext.CommandTimeout != null)
 			{
@@ -256,7 +256,14 @@ namespace Shaolinq.Persistence
 		[RewriteAsync]
 		public virtual void Rollback()
 		{
-			ActionUtils.IgnoreExceptions(() => ((IDataAccessModelInternal)this.DataAccessModel).OnHookBeforeRollback());
+			try
+			{
+				((IDataAccessModelInternal)this.DataAccessModel).OnHookBeforeRollback();
+			}
+			catch
+			{
+				// ignored
+			}
 
 			try
 			{
@@ -271,7 +278,14 @@ namespace Shaolinq.Persistence
 			{
 				CloseConnection();
 
-				ActionUtils.IgnoreExceptions(() => ((IDataAccessModelInternal)this.DataAccessModel).OnHookAfterRollback());
+				try
+				{
+					((IDataAccessModelInternal)this.DataAccessModel).OnHookAfterRollback();
+				}
+				catch
+				{
+					// ignored
+				}
 			}
 		}
 

--- a/src/Shaolinq/Shaolinq.csproj
+++ b/src/Shaolinq/Shaolinq.csproj
@@ -145,6 +145,8 @@
     <Compile Include="DataAccessIsolationLevel.cs" />
     <Compile Include="DataAccessModel+Hooks.cs" />
     <Compile Include="DataAccessModelHookBase.cs" />
+    <Compile Include="DataAccessModelHookContextBase.cs" />
+    <Compile Include="DataAccessModelHookRollbackContext.cs" />
     <Compile Include="DataAccessModelHookSubmitContext.cs" />
     <Compile Include="DataAccessObjectExtensions.cs" />
     <Compile Include="DirectAccess\Sql\DataAccessModelExtensions.cs" />

--- a/src/Shaolinq/TransactionContext.cs
+++ b/src/Shaolinq/TransactionContext.cs
@@ -146,6 +146,8 @@ namespace Shaolinq
 
 				return context;
 			}
+
+			dataAccessTransaction.CheckAborted();
 			
 			if (dataAccessTransaction.systemTransactionCompleted && dataAccessTransaction.systemTransactionStatus == TransactionStatus.Aborted)
 			{

--- a/src/Shaolinq/TransactionContext.cs
+++ b/src/Shaolinq/TransactionContext.cs
@@ -61,6 +61,8 @@ namespace Shaolinq
 		internal DataAccessTransaction DataAccessTransaction { get; }
 		private readonly Dictionary<string, object> attributes;
 		public string DatabaseContextCategoriesKey { get; internal set; }
+
+		public string TransactionContextId { get; }
 		
 		internal int GetExecutionVersion()
 		{
@@ -213,6 +215,7 @@ namespace Shaolinq
 
 		internal TransactionContext(DataAccessTransaction dataAccessTransaction, DataAccessModel dataAccessModel)
 		{
+			this.TransactionContextId = Guid.NewGuid().ToString("N");
 			this.dataAccessModel = dataAccessModel;
 			this.DataAccessTransaction = dataAccessTransaction;
 			this.DatabaseContextCategoriesKey = "*";

--- a/tests/Shaolinq.Tests/App.config
+++ b/tests/Shaolinq.Tests/App.config
@@ -17,7 +17,7 @@
 			<level value="Info"/>
 			<appender-ref ref="ConsoleAppender"/>
 		</logger>
-			<logger name="Shaolinq.ProjectionCache">
+		<logger name="Shaolinq.ProjectionCache">
 			<level value="Error"/>
 			<appender-ref ref="ConsoleAppender"/>
 		</logger>
@@ -27,9 +27,9 @@
 		<SqlDatabaseContexts>
 			<Postgres-DotConnect DatabaseName="StaticConfigTest" ServerName="localhost" UserId="postgres" Port="5432" Password="postgres" Pooling="True" MaxPoolSize="64"/>
 		</SqlDatabaseContexts>
-	<ReferencedTypes>
-		<Type Name="Shaolinq.DataAccessModel, Shaolinq"/>
-	</ReferencedTypes>
+		<ReferencedTypes>
+			<Type Name="Shaolinq.DataAccessModel, Shaolinq"/>
+		</ReferencedTypes>
 	</TestDataAccessModelPostgresDotConnect>
 	<startup>
 		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>

--- a/tests/Shaolinq.Tests/DataAccessModelHookTests.cs
+++ b/tests/Shaolinq.Tests/DataAccessModelHookTests.cs
@@ -40,7 +40,7 @@ namespace Shaolinq.Tests
 
 			public override void AfterSubmit(DataAccessModelHookSubmitContext context)
 			{
-				Console.WriteLine($"AfterSubmit - IsCommit: {context.IsCommit}, new objects: {context.New.Count()} {context.Exception?.Message}");
+				Console.WriteLine($"AfterSubmit {context.DataAccessTransactionId} {context.TransactionContextId} - IsCommit: {context.IsCommit}, new objects: {context.New.Count()} {context.Exception?.Message}");
 
 				if (context.IsCommit)
 				{
@@ -52,7 +52,7 @@ namespace Shaolinq.Tests
 
 			public override Task AfterSubmitAsync(DataAccessModelHookSubmitContext context, CancellationToken cancellationToken)
 			{
-				Console.WriteLine($"AfterSubmitAsync - IsCommit: {context.IsCommit}, new objects: {context.New.Count()} {context.Exception?.Message}");
+				Console.WriteLine($"AfterSubmitAsync {context.DataAccessTransactionId} {context.TransactionContextId} - IsCommit: {context.IsCommit}, new objects: {context.New.Count()} {context.Exception?.Message}");
 
 				if (context.IsCommit)
 				{
@@ -62,22 +62,22 @@ namespace Shaolinq.Tests
 				return base.AfterSubmitAsync(context, cancellationToken);
 			}
 
-			public override void AfterRollback()
+			public override void AfterRollback(DataAccessModelHookRollbackContext context)
 			{
-				Console.WriteLine("AfterRollback");
+				Console.WriteLine($"AfterRollback {context.DataAccessTransactionId} {context.TransactionContextId}");
 
 				this.RollbackCount++;
 
-				base.AfterRollback();
+				base.AfterRollback(context);
 			}
 
-			public override Task AfterRollbackAsync(CancellationToken cancellationToken)
+			public override Task AfterRollbackAsync(DataAccessModelHookRollbackContext context, CancellationToken cancellationToken)
 			{
-				Console.WriteLine("AfterRollbackAsync");
+				Console.WriteLine($"AfterRollbackAsync {context.DataAccessTransactionId} {context.TransactionContextId}");
 
 				this.RollbackCount++;
 
-				return base.AfterRollbackAsync(cancellationToken);
+				return base.AfterRollbackAsync(context, cancellationToken);
 			}
 		}
 

--- a/tests/Shaolinq.Tests/DataAccessModelHookTests.cs
+++ b/tests/Shaolinq.Tests/DataAccessModelHookTests.cs
@@ -1,0 +1,246 @@
+﻿using System;
+using System.Linq;
+using System.Transactions;
+using NUnit.Framework;
+using Shaolinq.Tests.ComplexPrimaryKeyModel;
+using Shaolinq.Tests.TestModel;
+
+namespace Shaolinq.Tests
+{
+	[TestFixture("MySql")]
+	[TestFixture("Sqlite")]
+	[TestFixture("SqliteInMemory")]
+	[TestFixture("SqliteClassicInMemory")]
+	[TestFixture("Sqlite:DataAccessScope")]
+	[TestFixture("SqlServer:DataAccessScope")]
+	[TestFixture("Postgres")]
+	[TestFixture("Postgres.DotConnect")]
+	public class DataAccessModelHookTests : BaseTests<TestDataAccessModel>
+	{
+		public class TestDataModelHook : DataAccessModelHookBase
+		{
+			public int AfterSubmitCallCompleteCount { get; private set; }
+
+			public override void Create(DataAccessObject dataAccessObject)
+			{
+				Console.WriteLine("Create");
+
+				base.Create(dataAccessObject);
+			}
+
+			public override void AfterSubmit(DataAccessModelHookSubmitContext context)
+			{
+				Console.WriteLine($"AfterSubmit - IsCommit: {context.IsCommit}, new objects: {context.New.Count()} {context.Exception?.Message}");
+
+				if (context.IsCommit)
+				{
+					this.AfterSubmitCallCompleteCount++;
+				}
+
+				base.AfterSubmit(context);
+			}
+		}
+
+		private TestDataModelHook testDataModelHook;
+		
+		public DataAccessModelHookTests(string providerName) : base(providerName)
+		{
+		}
+
+		[SetUp]
+		public void SetUp()
+		{
+			this.testDataModelHook = new TestDataModelHook();
+			this.model.AddHook(this.testDataModelHook);
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			this.model.RemoveHook(testDataModelHook);
+		}
+
+		[TestCase(false, false)]
+		[TestCase(false, true)]
+		[TestCase(true, false)]
+		[TestCase(true, true)]
+		public void Test_DataAccessScope_CreateFlushComplete_Calls_DataModelHook(bool flush, bool complete)
+		{
+			using (var scope = DataAccessScope.CreateReadCommitted())
+			{
+				var cat = this.model.Cats.Create();
+
+				Console.WriteLine("===");
+
+				if (flush) scope.Flush();
+				if (complete) scope.Complete();
+			}
+
+			Assert.AreEqual(this.testDataModelHook.AfterSubmitCallCompleteCount, complete ? 1 : 0);
+		}
+
+		[TestCase(false, false)]
+		[TestCase(false, true)]
+		[TestCase(true, false)]
+		[TestCase(true, true)]
+		public void Test_TransactionScope_CreateFlushComplete_Calls_DataModelHook(bool flush, bool complete)
+		{
+			using (var scope = new TransactionScope())
+			{
+				var cat = this.model.Cats.Create();
+
+				Console.WriteLine("===");
+
+				if (flush) scope.Flush();
+				if (complete) scope.Complete();
+			}
+
+			Assert.AreEqual(this.testDataModelHook.AfterSubmitCallCompleteCount, complete ? 1 : 0);
+		}
+
+
+		[TestCase(false, false)]
+		[TestCase(false, true)]
+		[TestCase(true, false)]
+		[TestCase(true, true)]
+		public void Test_Distributed_Transaction_DataAccessScope_CreateFlushComplete_Calls_DataModelHook(bool flush, bool complete)
+		{
+			var config2 = this.CreateSqliteClassicInMemoryConfiguration(null);
+			var model2 = DataAccessModel.BuildDataAccessModel<ComplexPrimaryKeyDataAccessModel>(config2);
+			var hook2 = new TestDataModelHook();
+			model2.AddHook(hook2);
+			model2.Create(DatabaseCreationOptions.IfDatabaseNotExist);
+
+			using (var scope = new DataAccessScope())
+			{
+				var cat = this.model.Cats.Create();
+				var coord = model2.Coordinates.Create(1);
+
+				Console.WriteLine("===");
+
+				if (flush) scope.Flush();
+				if (complete) scope.Complete();
+			}
+
+			Assert.AreEqual(this.testDataModelHook.AfterSubmitCallCompleteCount, complete ? 1 : 0);
+			Assert.AreEqual(hook2.AfterSubmitCallCompleteCount, complete ? 1 : 0);
+		}
+
+		[TestCase(false, false)]
+		[TestCase(false, true)]
+		[TestCase(true, false)]
+		[TestCase(true, true)]
+		public void Test_Distributed_Transaction_TransactionScope_CreateFlushComplete_Calls_DataModelHook(bool flush, bool complete)
+		{
+			var config2 = this.CreateSqliteClassicInMemoryConfiguration(null);
+			var model2 = DataAccessModel.BuildDataAccessModel<ComplexPrimaryKeyDataAccessModel>(config2);
+			var hook2 = new TestDataModelHook();
+			model2.AddHook(hook2);
+			model2.Create(DatabaseCreationOptions.IfDatabaseNotExist);
+
+			using (var scope = new TransactionScope())
+			{
+				var cat = this.model.Cats.Create();
+				var coord = model2.Coordinates.Create(1);
+
+				Console.WriteLine("===");
+
+				if (flush) scope.Flush();
+				if (complete) scope.Complete();
+			}
+
+			Assert.AreEqual(this.testDataModelHook.AfterSubmitCallCompleteCount, complete ? 1 : 0);
+			Assert.AreEqual(hook2.AfterSubmitCallCompleteCount, complete ? 1 : 0);
+		}
+
+		[TestCase(false, false)]
+		[TestCase(false, true)]
+		[TestCase(true, false)]
+		[TestCase(true, true)]
+		public void Test_Nested_DataAccessScope_Inner_Complete_Calls_DataModelHook(bool flush, bool complete)
+		{
+			using (var outerScope = new DataAccessScope())
+			{
+				var cat1 = this.model.Cats.Create();
+
+				using (var innerScope = new DataAccessScope())
+				{
+					var cat2 = this.model.Cats.Create();
+
+					innerScope.Complete();
+				}
+
+				var cat3 = this.model.Cats.Create();
+
+				if (flush) outerScope.Flush();
+				if (complete) outerScope.Complete();
+			}
+
+			Assert.AreEqual(this.testDataModelHook.AfterSubmitCallCompleteCount, complete ? 1 : 0);
+		}
+
+		[Test]
+		public void Test_Nested_DataAccessScope_Inner_Not_Complete_Should_Throw_TransactionAbortedException()
+		{
+			using (var outerScope = new DataAccessScope())
+			{
+				var cat1 = this.model.Cats.Create();
+
+				using (var innerScope = new DataAccessScope())
+				{
+					var cat2 = this.model.Cats.Create();
+				}
+
+				Assert.Throws<TransactionAbortedException>(() =>
+				{
+					var cat3 = this.model.Cats.Create();
+				});
+			}
+		}
+
+		[TestCase(false, false)]
+		[TestCase(false, true)]
+		[TestCase(true, false)]
+		[TestCase(true, true)]
+		public void Test_Nested_TransactionScope_Inner_Complete_Calls_DataModelHook(bool flush, bool complete)
+		{
+			using (var outerScope = new TransactionScope())
+			{
+				var cat1 = this.model.Cats.Create();
+
+				using (var innerScope = new TransactionScope())
+				{
+					var cat2 = this.model.Cats.Create();
+
+					innerScope.Complete();
+				}
+
+				var cat3 = this.model.Cats.Create();
+
+				if (flush) outerScope.Flush();
+				if (complete) outerScope.Complete();
+			}
+
+			Assert.AreEqual(this.testDataModelHook.AfterSubmitCallCompleteCount, complete ? 1 : 0);
+		}
+
+		[Test]
+		public void Test_Nested_TransactionScope_Inner_Not_Complete_Should_Throw_TransactionAbortedException()
+		{
+			using (var outerScope = new TransactionScope())
+			{
+				var cat1 = this.model.Cats.Create();
+
+				using (var innerScope = new TransactionScope())
+				{
+					var cat2 = this.model.Cats.Create();
+				}
+
+				Assert.Throws<TransactionAbortedException>(() =>
+				{
+					var cat3 = this.model.Cats.Create();
+				});
+			}
+		}
+	}
+}

--- a/tests/Shaolinq.Tests/DataAccessModelHookTests.cs
+++ b/tests/Shaolinq.Tests/DataAccessModelHookTests.cs
@@ -360,5 +360,47 @@ namespace Shaolinq.Tests
 
 			Assert.AreEqual(completeOuter && completeInner ? 1 : 0, this.testDataModelHook.CommitCount);
 		}
+
+		[Test]
+		public void Test_DataAccessScope_InvalidTransaction_ShouldCallRollbackHook()
+		{
+			var ex = Assert.Throws<DataAccessTransactionAbortedException>(
+				() =>
+				{
+					using (var scope = new DataAccessScope())
+					{
+						var obj = this.model.DefaultsTestObjects.Create();
+
+						// Value required fields not populated
+
+						scope.Complete();
+					}
+				});
+
+			Console.WriteLine(ex);
+
+			Assert.AreEqual(1, this.testDataModelHook.RollbackCount);
+		}
+
+		[Test]
+		public void Test_TransactionScope_InvalidTransaction_ShouldCallRollbackHook()
+		{
+			var ex = Assert.Throws<TransactionAbortedException>(
+				() =>
+				{
+					using (var scope = new TransactionScope())
+					{
+						var obj = this.model.DefaultsTestObjects.Create();
+
+						// Value required fields not populated
+
+						scope.Complete();
+					}
+				});
+
+			Console.WriteLine(ex);
+
+			Assert.AreEqual(1, this.testDataModelHook.RollbackCount);
+		}
 	}
 }

--- a/tests/Shaolinq.Tests/Shaolinq.Tests.csproj
+++ b/tests/Shaolinq.Tests/Shaolinq.Tests.csproj
@@ -220,6 +220,7 @@
     <Compile Include="ComputedMemberTests.cs" />
     <Compile Include="ConfigurationTests.cs" />
     <Compile Include="ConstraintTests.cs" />
+    <Compile Include="DataAccessModelHookTests.cs" />
     <Compile Include="FixedDate.cs" />
     <Compile Include="DirectAccessTests.cs" />
     <Compile Include="GenericModel\DbUser.cs" />

--- a/tests/Shaolinq.Tests/TestDataAccessModel.configx
+++ b/tests/Shaolinq.Tests/TestDataAccessModel.configx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <TestDataAccessModel configSource="TestDataAccessModel.configx">
-<SqlDatabaseContexts>
-    <Sqlite FileName=":memory:" />
-</SqlDatabaseContexts>
+	<SqlDatabaseContexts>
+		<Sqlite FileName=":memory:" />
+	</SqlDatabaseContexts>
 </TestDataAccessModel>


### PR DESCRIPTION
A few changes to Data Access Hooks:

- adds `BeforeRollback` and `AfterRollback` hooks
- adds IDs to `DataAccessTransaction` and `TransactionContext` which are available in the Submit and Rollback hooks
- Adds some tests around submit and rollback hooks
- Fixes some bugs