### PR TITLE
Connection properties not mapped to connection string builder

### DIFF
--- a/src/Shaolinq.Postgres.DotConnect/PostgresDotConnectSqlDatabaseContext.cs
+++ b/src/Shaolinq.Postgres.DotConnect/PostgresDotConnectSqlDatabaseContext.cs
@@ -54,8 +54,10 @@ namespace Shaolinq.Postgres.DotConnect
 					Enlist = false,
 					Charset = "UTF8",
 					Unicode = true,
+					MinPoolSize = contextInfo.MinPoolSize,
 					MaxPoolSize = contextInfo.MaxPoolSize,
-					UnpreparedExecute = contextInfo.UnpreparedExecute
+					UnpreparedExecute = contextInfo.UnpreparedExecute,
+					KeepAlive = contextInfo.KeepAlive
 				};
 
 				if (contextInfo.ConnectionTimeout != null)

--- a/src/Shaolinq.Postgres/PostgresSqlDatabaseContext.cs
+++ b/src/Shaolinq.Postgres/PostgresSqlDatabaseContext.cs
@@ -51,6 +51,7 @@ namespace Shaolinq.Postgres
 				MaxPoolSize = contextInfo.MaxPoolSize,
 				KeepAlive = contextInfo.KeepAlive,
 				ConnectionIdleLifetime = contextInfo.ConnectionIdleLifetime,
+				ConnectionPruningInterval = contextInfo.ConnectionPruningInterval,
 				ConvertInfinityDateTime = contextInfo.ConvertInfinityDateTime
 			};
 


### PR DESCRIPTION
Some connection properties were not being mapped to the connection string builder.